### PR TITLE
docs: add python 3.9 availability to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ packages are only built for the amd64 architecture for the following:
 
 - python3.7 (xenial, bionic)
 - python3.8 (xenial, bionic)
+- python3.9 (xenial, bionic)


### PR DESCRIPTION
As far as I can see and understand Python 3.9 is available through this repository as well. The availability should be documented for users in the `README.md`.