### PR TITLE
Dropping support for nightly python3.10 on xenial

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ packages are only built for the amd64 architecture for the following:
 - [![Build Status](https://github.com/deadsnakes/python3.7-nightly/workflows/main/badge.svg)](https://github.com/deadsnakes/python3.7-nightly/actions) python3.7 (xenial, bionic)
 - [![Build Status](https://github.com/deadsnakes/python3.8-nightly/workflows/main/badge.svg)](https://github.com/deadsnakes/python3.8-nightly/actions) python3.8 (xenial, bionic)
 - [![Build Status](https://github.com/deadsnakes/python3.9-nightly/workflows/main/badge.svg)](https://github.com/deadsnakes/python3.9-nightly/actions) python3.9 (xenial, bionic, focal)
-- [![Build Status](https://github.com/deadsnakes/python3.10-nightly/workflows/main/badge.svg)](https://github.com/deadsnakes/python3.10-nightly/actions) python3.10 (xenial, bionic, focal)
+- [![Build Status](https://github.com/deadsnakes/python3.10-nightly/workflows/main/badge.svg)](https://github.com/deadsnakes/python3.10-nightly/actions) python3.10 (bionic, focal)


### PR DESCRIPTION
libssl1.1 is required for python3.10